### PR TITLE
Fix config modification permitted for all LAN players

### DIFF
--- a/src/main/java/com/iafenvoy/jupiter/ServerConfigManager.java
+++ b/src/main/java/com/iafenvoy/jupiter/ServerConfigManager.java
@@ -54,7 +54,7 @@ public class ServerConfigManager implements ResourceManagerReloadListener {
         PermissionChecker ALWAYS_TRUE = (server, player) -> true;
         PermissionChecker ALWAYS_FALSE = (server, player) -> false;
         PermissionChecker IS_DEDICATE_SERVER = (server, player) -> server.isDedicatedServer();
-        PermissionChecker IS_LOCAL_GAME = (server, player) -> !IS_DEDICATE_SERVER.check(server, player);
+        PermissionChecker IS_LOCAL_GAME = (server, player) -> server.isSingleplayerOwner(player.getGameProfile());
         PermissionChecker IS_OPERATOR = (server, player) -> IS_LOCAL_GAME.check(server, player) || player.hasPermissions(server./*? >=1.21.9 {*//*operatorUserPermissionLevel*//*?} else {*/getOperatorUserPermissionLevel/*?}*/());
 
         boolean check(MinecraftServer server, ServerPlayer player);


### PR DESCRIPTION
Hello, I was reviewing the security of this mod and found one concern:

Currently the `IS_LOCAL_GAME` and dependent `IS_OPERATOR` permission predicates use `!server.isDedicatedServer()`, which incorrectly allows for any player connected to a LAN game to modify server configs.

This PR changes `IS_LOCAL_GAME` to use `server.isSingleplayerOwner(player.getGameProfile())`, which correctly identifies only the world owner.

LAN of course should be secure, but the risk is heightened if used along side mods such as [e4mc](https://modrinth.com/mod/e4mc) which can expose LAN games to the wider internet.

Let me know if any changes are needed!